### PR TITLE
Convert facets to aggregations for searchkick 2.0, elasticsearch 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Features
 --------
 
 * Full search (keyword, in_taxon)
-* Taxons Filters (facets)
+* Taxons Aggregations (aggs)
 * Search Autocomplete ([Typeahead](https://twitter.github.io/typeahead.js/))
 * Added `/best` route, where best selling products are boosted in first page
 

--- a/app/assets/javascripts/spree/frontend/spree_searchkick.js
+++ b/app/assets/javascripts/spree/frontend/spree_searchkick.js
@@ -7,9 +7,9 @@ $(function () {
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
     limit: 10,
-    prefetch: '/autocomplete/products.json',
+    prefetch: Spree.mountedAt() + '/autocomplete/products.json',
     remote: {
-      url: '/autocomplete/products.json?keywords=%QUERY',
+      url: Spree.mountedAt() + '/autocomplete/products.json?keywords=%QUERY',
       wildcard: '%QUERY'
     }
   });

--- a/app/views/spree/shared/_filters.html.erb
+++ b/app/views/spree/shared/_filters.html.erb
@@ -1,6 +1,6 @@
 <%
-  facets = @products.facets
-  filters = Spree::Core::SearchkickFilters.applicable_filters(facets)
+  aggregations = @products.aggs
+  filters = Spree::Core::SearchkickFilters.applicable_filters(aggregations)
 %>
 <%= form_tag '', :method => :get, :id => 'sidebar_products_search' do %>
   <%= hidden_field_tag 'per_page', params[:per_page] %>

--- a/lib/spree/core/searchkick_filters.rb
+++ b/lib/spree/core/searchkick_filters.rb
@@ -1,14 +1,14 @@
 module Spree
   module Core
     module SearchkickFilters
-      def self.applicable_filters(facets)
+      def self.applicable_filters(aggregations)
         es_filters = []
         Spree::Taxonomy.filterable.each do |taxonomy|
-          es_filters << self.process_filter(taxonomy.filter_name, :taxon, facets[taxonomy.filter_name])
+          es_filters << self.process_filter(taxonomy.filter_name, :taxon, aggregations[taxonomy.filter_name])
         end
 
         Spree::Property.filterable.each do |property|
-          es_filters << self.process_filter(property.filter_name, :property, facets[property.filter_name])
+          es_filters << self.process_filter(property.filter_name, :property, aggregations[property.filter_name])
         end
 
         es_filters.uniq
@@ -18,19 +18,19 @@ module Spree
         options = []
         case type
         when :price
-          min = filter["terms"].min {|a,b| a["term"] <=> b["term"] }
-          max = filter["terms"].max {|a,b| a["term"] <=> b["term"] }
+          min = filter["buckets"].min {|a,b| a["key"] <=> b["key"] }
+          max = filter["buckets"].max {|a,b| a["key"] <=> b["key"] }
           if min && max
-            options = {min: min["term"].to_i, max: max["term"].to_i, step: 100}
+            options = {min: min["key"].to_i, max: max["key"].to_i, step: 100}
           else
             options = {}
           end
         when :taxon
-          ids = filter["terms"].map{|h| h["term"]}
+          ids = filter["buckets"].map{|h| h["key"]}
           taxons = Spree::Taxon.where(id: ids).order(name: :asc)
           taxons.each {|t| options << {label: t.name, value: t.id }}
         when :property
-          values = filter["terms"].map{|h| h["term"]}
+          values = filter["buckets"].map{|h| h["key"]}
           values.each {|t| options << {label: t, value: t }}
         end
 
@@ -42,8 +42,8 @@ module Spree
 
       end
 
-      def self.facet_term(facet)
-        facet["terms"].sort_by { |hsh| hsh["term"] }
+      def self.aggregation_term(aggregation)
+        aggregation["buckets"].sort_by { |hsh| hsh["key"] }
       end
     end
   end

--- a/lib/spree/search/searchkick.rb
+++ b/lib/spree/search/searchkick.rb
@@ -6,7 +6,7 @@ module Spree::Search
 
     def get_base_elasticsearch
       curr_page = page || 1
-      Spree::Product.search(keyword_query, where: where_query, facets: facets, smart_facets: true, order: sorted, page: curr_page, per_page: per_page)
+      Spree::Product.search(keyword_query, where: where_query, aggs: aggregations, smart_aggs: true, order: sorted, page: curr_page, per_page: per_page)
     end
 
     def where_query
@@ -29,7 +29,7 @@ module Spree::Search
       order_params
     end
 
-    def facets
+    def aggregations
       fs = []
       Spree::Taxonomy.filterable.each do |taxonomy|
         fs << taxonomy.filter_name.to_sym

--- a/spec/lib/spree/search/searchkick_spec.rb
+++ b/spec/lib/spree/search/searchkick_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+describe Spree::Search::Searchkick do
+  let(:product) { create(:product) }
+
+  before do
+    product.reindex
+    Spree::Product.reindex
+  end
+
+  describe "#retrieve_products" do
+    it "returns matching products" do
+      products = Spree::Search::Searchkick.new({}).retrieve_products
+      expect(products.count).to eq 1
+    end
+
+    describe "aggregations" do
+      let(:taxonomy) { Spree::Taxonomy.where(id: 1, name: "Category").first_or_create }
+
+      before do
+        product.taxons << taxonomy.root
+        product.reindex
+        Spree::Product.reindex
+      end
+
+      it "has no aggregations by default" do
+        products = Spree::Search::Searchkick.new({}).retrieve_products
+        expect(products.aggs).to be_nil
+      end
+
+      context "with a filterable taxonomy" do
+        let(:taxonomy) { Spree::Taxonomy.where(id: 1, name: "Category", filterable: true).first_or_create }
+
+        it "retrieves aggregations" do
+          products = Spree::Search::Searchkick.new({}).retrieve_products
+
+          expect(products.count).to eq 1
+          expect(products.aggs["category_ids"]).to include("doc_count" => 1)
+          expect(products.aggs["category_ids"]["buckets"]).to be_a Array
+        end
+      end
+    end
+  end
+end

--- a/spree_searchkick.gemspec
+++ b/spree_searchkick.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '~> 3.0.0'
-  s.add_dependency 'searchkick'
+  s.add_dependency 'searchkick', '>= 1.2'
 
   s.add_development_dependency 'capybara', '~> 2.4'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
I was looking to add searchkick on a spree project and found that facets have been deprecated.  I don't see any specs specifically related to the facets (or aggregations in 2.0).  I'll add a couple before this is ready to merge.

Do you have any thoughts about whether this should be merged against the 3-0 branch or master?  Also, any ideas on how you think we should version searchkick?
