### PR TITLE
Add Spree::Product last updated_at to the cache key

### DIFF
--- a/app/helpers/spree/products_helper_decorator.rb
+++ b/app/helpers/spree/products_helper_decorator.rb
@@ -2,6 +2,7 @@ Spree::ProductsHelper.module_eval do
   def cache_key_for_products
     count = @products.count
     hash = Digest::SHA1.hexdigest(params.to_json)
-    "#{I18n.locale}/#{current_currency}/spree/products/all-#{params[:page]}-#{hash}-#{count}"
+    max_updated_at = @products.records.maximum(:updated_at) || Date.today
+    "#{I18n.locale}/#{current_currency}/spree/products/all-#{params[:page]}-#{hash}-#{count}-#{max_updated_at.to_s(:number)}"
   end
 end


### PR DESCRIPTION
Our cache wasn't getting invalidated after updating products. By adding the last time a product was updated to the cache key, we were able to see the updated product details in the search results.

/@gaqzi and @rhlrjv, pairing
