### PR TITLE
Update gemspec to support Spree 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '3-0-stable'
+gem 'spree', github: 'spree/spree', branch: '3-1-stable'
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-0-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-1-stable'
 
 # Provides searchkick functionalities for testing
 gem 'searchkick', '>= 1.2'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add searchkick and spree_searchkick to your Gemfile:
 
 ```ruby
 gem 'searchkick'
-gem 'spree_searchkick', github: 'ronzalo/spree_searchkick', branch: '3-0-stable'
+gem 'spree_searchkick', github: 'ronzalo/spree_searchkick', branch: '3-1-stable'
 ```
 
 Bundle your dependencies and run the installation generator:

--- a/spree_searchkick.gemspec
+++ b/spree_searchkick.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.0.0'
+  s.add_dependency 'spree_core', '~> 3.1.0'
   s.add_dependency 'searchkick', '>= 1.2'
 
   s.add_development_dependency 'capybara', '~> 2.4'


### PR DESCRIPTION
This commit depends on https://github.com/spree/spree/pull/7486 to work. If the PR gets rejected I'll make it part of the extension instead, but it felt like something that should be in core.
