### PR TITLE
Don't autocomplete for unavailable products

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -33,9 +33,23 @@ Spree::Product.class_eval do
 
   def self.autocomplete(keywords)
     if keywords
-      Spree::Product.search(keywords, autocomplete: true, limit: 10).map(&:name).map(&:strip).uniq
+      Spree::Product.search(
+        keywords,
+        autocomplete: true,
+        limit: 10, where: search_where
+      ).map(&:name).map(&:strip).uniq
     else
-      Spree::Product.search('*').map(&:name).map(&:strip)
+      Spree::Product.search(
+        '*',
+        where: search_where
+      ).map(&:name).map(&:strip)
     end
+  end
+
+  def self.search_where
+    {
+      active: true,
+      price: { not: nil }
+    }
   end
 end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -13,5 +13,25 @@ RSpec.describe Spree::Product, type: :model do
       keyword = product.name[0..3]
       expect(Spree::Product.autocomplete(keyword)).to eq([product.name.strip])
     end
+
+    context 'products that are not yet available' do
+      let(:product) { create(:product, available_on: nil) }
+
+      it 'does not return them in autocomplete' do
+        keyword = product[0..3]
+        expect(Spree::Product.autocomplete(keyword)).to eq([])
+      end
+    end
+
+    context 'products with no price' do
+      let(:product) do
+        create(:product).tap { |_| Spree::Price.update_all(amount: nil) }
+      end
+
+      it 'does not return them in autocomplete' do
+        keyword = product[0..3]
+        expect(Spree::Product.autocomplete(keyword)).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
The decision to not search for products with no price and not active
matches the search results when you hit enter.

Before this change you could hit enter for the autocomplete and get
a page saying the product couldn't be found.
