### PR TITLE
Run test elasticseach cluster in specs

### DIFF
--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -1,0 +1,25 @@
+require 'elasticsearch/extensions/test/cluster'
+
+RSpec.configure do |config|
+  unless ENV['CI']
+    config.before(:suite) { start_elastic_cluster }
+
+    config.after(:suite) { stop_elastic_cluster }
+  end
+end
+
+def start_elastic_cluster
+  ENV['TEST_CLUSTER_PORT'] = '9250'
+  ENV['TEST_CLUSTER_NODES'] = '1'
+  ENV['TEST_CLUSTER_NAME'] = 'spree_searchkick_test'
+
+  ENV['ELASTICSEARCH_URL'] = "http://localhost:#{ENV['TEST_CLUSTER_PORT']}"
+
+  return if Elasticsearch::Extensions::Test::Cluster.running?
+  Elasticsearch::Extensions::Test::Cluster.start(timeout: 10)
+end
+
+def stop_elastic_cluster
+  return unless Elasticsearch::Extensions::Test::Cluster.running?
+  Elasticsearch::Extensions::Test::Cluster.stop
+end

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -6,6 +6,23 @@ RSpec.configure do |config|
 
     config.after(:suite) { stop_elastic_cluster }
   end
+
+  SEARCHABLE_MODELS = [Spree::Product].freeze
+
+  # create indices for searchable models
+  config.before do
+    SEARCHABLE_MODELS.each do |model|
+      model.reindex
+      model.searchkick_index.refresh
+    end
+  end
+
+  # delete indices for searchable models to keep clean state between tests
+  config.after do
+    SEARCHABLE_MODELS.each do |model|
+      model.searchkick_index.delete
+    end
+  end
 end
 
 def start_elastic_cluster

--- a/spree_searchkick.gemspec
+++ b/spree_searchkick.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
+  s.add_development_dependency 'elasticsearch-extensions'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
I tried to run tests locally, but didn't have elasticsearch started as service

This fix adds running elasticsearch on tests run

It uses elasticsearch installed in system, but starts new test cluster

more info here: https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-extensions#testcluster

Also fixes this flaky error on CI:

```
 Elasticsearch::Transport::Transport::Errors::NotFound:
       [404] {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such 
```